### PR TITLE
Add a test for URL escaping bug

### DIFF
--- a/tests/XssTest.php
+++ b/tests/XssTest.php
@@ -733,6 +733,7 @@ textContent>click me!',
         "<a href=\"https://sellercentral.amazon.com/gp/change-password/change-password-em ail.html?errorMessage=I'm%20sorry,%20the%20Password%20Assistance%20pag e%20is%20temporarily%20unavailable.%20%20Please%20try%20again%20in%201 5%2\">test</a>" => "<a href=\"https://sellercentral.amazon.com/gp/change-password/change-password-em ail.html?errorMessage=I'm%20sorry,%20the%20Password%20Assistance%20pag e%20is%20temporarily%20unavailable.%20%20Please%20try%20again%20in%201 5%2\">test</a>",
         "https://sellercentral.amazon.com/gp/change-password/change-password-em ail.html?errorMessage=I'm%20sorry,%20the%20Password%20Assistance%20pag e%20is%20temporarily%20unavailable.%20%20Please%20try%20again%20in%201 5%2" => "https://sellercentral.amazon.com/gp/change-password/change-password-em ail.html?errorMessage=I'm sorry, the Password Assistance pag e is temporarily unavailable.  Please try again in 1 5%2",
         'http://www.amazon.com/script-alert-product-document-cookie/dp/B003H777 5E/ref=sr_1_3?s=gateway&amp;ie=UTF8&amp;qid=1285870078&amp;sr=8-3' => 'http://www.amazon.com/script-alert-product-document-cookie/dp/B003H777 5E/ref=sr_1_3?s=gateway&ie=UTF8&qid=1285870078&sr=8-3',
+        'https://acme.com/i-ker/kiado+lakas/tegla-epitesu-lakas/budapest+1+kerulet+batthyany+ter/123454' => 'https://acme.com/i-ker/kiado+lakas/tegla-epitesu-lakas/budapest+1+kerulet+batthyany+ter/123454',
     );
 
     foreach ($testArray as $before => $after) {


### PR DESCRIPTION
Hello!

I think we have a bug when an URL have a `+param/other-` sequence it removes. I added a failing test case for that. It caused by this regex https://github.com/voku/anti-xss/blob/master/src/voku/helper/AntiXSS.php#L2731

Could you have a look, please? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/29)
<!-- Reviewable:end -->
