### PR TITLE
UTF7 repack corrected

### DIFF
--- a/src/voku/helper/AntiXSS.php
+++ b/src/voku/helper/AntiXSS.php
@@ -2711,7 +2711,7 @@ final class AntiXSS
   /**
    * Additional UTF-7 decoding function.
    *
-   * @param string $str <p>String for recode ASCII part of UTF-7 back to ASCII.</p>
+   * @param array $str <p>String for recode ASCII part of UTF-7 back to ASCII.</p>
    *
    * @return string
    */
@@ -2720,7 +2720,10 @@ final class AntiXSS
     $strTmp = \base64_decode($str[1]);
 
     if ($strTmp === false) {
-      return $str;
+      return $str[0]; //return original string insted of array
+    }
+    if(base64_encode($strTmp)!==$str){ //if reencoded != original  - string is not utf7
+      return $str[0]; //return original string insted of array
     }
 
     $str = (string)\preg_replace_callback(


### PR DESCRIPTION
function _repack_utf7_callback is converting incorrectly non utf7 strings.
example:  Chassis+FanTray10G-VSS  is removed from original html (text)

when added a test to detect if base64_encode(base64_decode($str))===$str
PHP was thrown an error: return must be string, returned array

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/34)
<!-- Reviewable:end -->
