### PR TITLE
perf: do a initial peak with the 3rd char of each event

### DIFF
--- a/src/voku/helper/AntiXSS.php
+++ b/src/voku/helper/AntiXSS.php
@@ -775,6 +775,19 @@ final class AntiXSS
     private function _do_never_allowed_afterwards(string $str)
     {
         if (\stripos($str, 'on') !== false) {
+            $never_allowed_and_likely_contained = [];
+            $thirdChar = '';
+            foreach ($this->_never_allowed_on_events_afterwards as $event) {
+                if ($event[2] === $thirdChar) {
+                    continue;
+                }
+
+                $thirdChar = $event[2];
+                if (\stripos($str, 'on'. $thirdChar) !== false) {
+                    $never_allowed_and_likely_contained[] = $event;
+                }
+            }
+            
             foreach ($this->_never_allowed_on_events_afterwards as $event) {
                 if (\stripos($str, $event) !== false) {
                     $regex = '(?<before>[^\p{L}]|^)(?:' . $event . ')(?<after>\(.*?\)|.*?>|(?:\s|\[.*?\])*?=(?:\s|\[.*?\])*?|(?:\s|\[.*?\])*?&equals;(?:\s|\[.*?\])*?|[^\p{L}]*?=[^\p{L}]*?|[^\p{L}]*?&equals;[^\p{L}]*?|$|\s*?>*?$)';

--- a/src/voku/helper/AntiXSS.php
+++ b/src/voku/helper/AntiXSS.php
@@ -788,7 +788,7 @@ final class AntiXSS
                 }
             }
             
-            foreach ($this->_never_allowed_on_events_afterwards as $event) {
+            foreach ($never_allowed_and_likely_contained as $event) {
                 if (\stripos($str, $event) !== false) {
                     $regex = '(?<before>[^\p{L}]|^)(?:' . $event . ')(?<after>\(.*?\)|.*?>|(?:\s|\[.*?\])*?=(?:\s|\[.*?\])*?|(?:\s|\[.*?\])*?&equals;(?:\s|\[.*?\])*?|[^\p{L}]*?=[^\p{L}]*?|[^\p{L}]*?&equals;[^\p{L}]*?|$|\s*?>*?$)';
 


### PR DESCRIPTION
this way we get a better idea which events actually might likely be contained. this effectivly reduces calls to stripos() which speeds up filtering.

refs https://github.com/voku/anti-xss/issues/64

with this PR we see speedups from 15-20%

![grafik](https://user-images.githubusercontent.com/120441/99717688-04e73400-2aaa-11eb-997b-2cd90f8eeec3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/65)
<!-- Reviewable:end -->
