### PR TITLE
Null Safety Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "::set-output name=directory::$(composer config cache-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.4.0
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/src/voku/helper/AntiXSS.php
+++ b/src/voku/helper/AntiXSS.php
@@ -531,9 +531,7 @@ final class AntiXSS
                 },
                 $str
             );
-            if ($tmp !== null) {
-                $str = (string) $tmp;
-            }
+            $str = $tmp ?? $str;
         }
 
         return $str;
@@ -641,9 +639,7 @@ final class AntiXSS
                 },
                 $str
             );
-            if ($tmp !== null) {
-                $str = (string) $tmp;
-            }
+            $str = $tmp ?? $str;
         } else {
             $str = UTF8::rawurldecode($str);
         }
@@ -694,9 +690,7 @@ final class AntiXSS
         // remove all >= 4-Byte chars if needed
         if ($this->_stripe_4byte_chars) {
             $tmp = \preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $str);
-            if ($tmp !== null) {
-                $str = (string) $tmp;
-            }
+            $str = $tmp ?? $str;
         }
 
         // backup the string (for later comparison)
@@ -776,9 +770,7 @@ final class AntiXSS
                 '$1' . $this->_replacement . '$2',
                 $str
             );
-            if ($tmp !== null) {
-                $str = (string) $tmp;
-            }
+            $str = $tmp ?? $str;
         }
 
         // ---
@@ -796,9 +788,7 @@ final class AntiXSS
                 $replacement,
                 $str
             );
-            if ($tmp !== null) {
-                $str = (string) $tmp;
-            }
+            $str = $tmp ?? $str;
         }
 
         if (!$this->_cache_never_allowed_regex_string || $regex_combined !== []) {
@@ -811,9 +801,7 @@ final class AntiXSS
                 $this->_replacement,
                 $str
             );
-            if ($tmp !== null) {
-                $str = (string) $tmp;
-            }
+            $str = $tmp ?? $str;
         }
 
         return $str;
@@ -873,9 +861,7 @@ final class AntiXSS
                             -1,
                             $temp_count
                         );
-                        if ($tmp !== null) {
-                            $str = (string) $tmp;
-                        }
+                        $str = $tmp ?? $str;
                         $count += $temp_count;
                     } while ($count);
 
@@ -1169,9 +1155,7 @@ final class AntiXSS
                             $search . '="' . $this->_replacement . '"',
                             $replacer
                         );
-                        if ($tmp !== null) {
-                            $replacer = (string) $tmp;
-                        }
+                        $replacer = $tmp ?? $replacer;
                     }
                 }
             }
@@ -1192,9 +1176,7 @@ final class AntiXSS
                         $search . '="' . $this->_replacement . '"',
                         $replacer
                     );
-                    if ($tmp !== null) {
-                        $replacer = (string) $tmp;
-                    }
+                    $replacer = $tmp ?? $replacer;
                 }
             }
         }
@@ -1436,9 +1418,7 @@ final class AntiXSS
                     -1,
                     $temp_count
                 );
-                if ($tmp !== null) {
-                    $str = (string) $tmp;
-                }
+                $str = $tmp ?? $str;
                 $count += $temp_count;
             } while ($count);
         }

--- a/src/voku/helper/AntiXSS.php
+++ b/src/voku/helper/AntiXSS.php
@@ -520,7 +520,7 @@ final class AntiXSS
             //
             // That way valid stuff like "dealer to!" does not become "dealerto".
 
-            $str = (string) \preg_replace_callback(
+            $tmp = \preg_replace_callback(
                 '#(?<before>[^\p{L}]|^)(?<word>' . \str_replace(
                     ['#', '.'],
                     ['\#', '\.'],
@@ -531,6 +531,9 @@ final class AntiXSS
                 },
                 $str
             );
+            if ($tmp !== null) {
+                $str = (string) $tmp;
+            }
         }
 
         return $str;
@@ -631,13 +634,16 @@ final class AntiXSS
             &&
             \preg_match($regExForHtmlTags, $str)
         ) {
-            $str = (string) \preg_replace_callback(
+            $tmp = \preg_replace_callback(
                 $regExForHtmlTags,
                 function ($matches) {
                     return $this->_decode_entity($matches);
                 },
                 $str
             );
+            if ($tmp !== null) {
+                $str = (string) $tmp;
+            }
         } else {
             $str = UTF8::rawurldecode($str);
         }
@@ -687,7 +693,10 @@ final class AntiXSS
 
         // remove all >= 4-Byte chars if needed
         if ($this->_stripe_4byte_chars) {
-            $str = (string) \preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $str);
+            $tmp = \preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $str);
+            if ($tmp !== null) {
+                $str = (string) $tmp;
+            }
         }
 
         // backup the string (for later comparison)
@@ -762,11 +771,14 @@ final class AntiXSS
             }
         }
         if (\count($replaceNeverAllowedCall) > 0) {
-            $str = (string) \preg_replace(
+            $tmp = \preg_replace(
                 '#([^\p{L}]|^)(?:' . \implode('|', $replaceNeverAllowedCall) . ')\s*:(?:.*?([/\\\;()\'">]|$))#ius',
                 '$1' . $this->_replacement . '$2',
                 $str
             );
+            if ($tmp !== null) {
+                $str = (string) $tmp;
+            }
         }
 
         // ---
@@ -779,11 +791,14 @@ final class AntiXSS
                 continue;
             }
 
-            $str = (string) \preg_replace(
+            $tmp = \preg_replace(
                 '#' . $regex . '#iUus',
                 $replacement,
                 $str
             );
+            if ($tmp !== null) {
+                $str = (string) $tmp;
+            }
         }
 
         if (!$this->_cache_never_allowed_regex_string || $regex_combined !== []) {
@@ -791,11 +806,14 @@ final class AntiXSS
         }
 
         if ($this->_cache_never_allowed_regex_string) {
-            $str = (string) \preg_replace(
+            $tmp = \preg_replace(
                 '#' . $this->_cache_never_allowed_regex_string . '#ius',
                 $this->_replacement,
                 $str
             );
+            if ($tmp !== null) {
+                $str = (string) $tmp;
+            }
         }
 
         return $str;
@@ -848,13 +866,16 @@ final class AntiXSS
                     do {
                         $count = $temp_count = 0;
 
-                        $str = (string) \preg_replace(
+                        $tmp = \preg_replace(
                             '#' . $regex . '#ius',
                             '$1' . $this->_replacement . '$2',
                             $str,
                             -1,
                             $temp_count
                         );
+                        if ($tmp !== null) {
+                            $str = (string) $tmp;
+                        }
                         $count += $temp_count;
                     } while ($count);
 
@@ -1143,11 +1164,14 @@ final class AntiXSS
                         $foundSomethingBad = true;
                         $this->_xss_found = true;
 
-                        $replacer = (string) \preg_replace(
+                        $tmp = \preg_replace(
                             $pattern,
                             $search . '="' . $this->_replacement . '"',
                             $replacer
                         );
+                        if ($tmp !== null) {
+                            $replacer = (string) $tmp;
+                        }
                     }
                 }
             }
@@ -1163,11 +1187,14 @@ final class AntiXSS
                 $pattern = '#' . $search . '=.*(?:' . $patternTmp . \implode('|', $this->_never_allowed_js_callback_regex) . ')#ius';
                 $matchInner = [];
                 if (\preg_match($pattern, $match[1], $matchInner)) {
-                    $replacer = (string) \preg_replace(
+                    $tmp = \preg_replace(
                         $pattern,
                         $search . '="' . $this->_replacement . '"',
                         $replacer
                     );
+                    if ($tmp !== null) {
+                        $replacer = (string) $tmp;
+                    }
                 }
             }
         }
@@ -1402,13 +1429,16 @@ final class AntiXSS
             do {
                 $count = $temp_count = 0;
 
-                $str = (string) \preg_replace(
+                $tmp = \preg_replace(
                     '/(<[^>]+)(?<!\p{L})(style\s*=\s*"(?:[^"]*?)"|style\s*=\s*\'(?:[^\']*?)\')/iu',
                     '$1' . $this->_replacement,
                     $str,
                     -1,
                     $temp_count
                 );
+                if ($tmp !== null) {
+                    $str = (string) $tmp;
+                }
                 $count += $temp_count;
             } while ($count);
         }


### PR DESCRIPTION
The original code used `(string) \preg_replace(...)` directly. If `preg_replace` returns `null` (due to PCRE errors, malformed regex, or memory issues), casting `null` to a string results in an empty string `""`. This caused form data to be lost, making forms appear blank after processing.

https://www.php.net/manual/en/function.preg-replace.php

To prevent data loss when `preg_replace` fails, a null safety check has been implemented. The pattern `$str = (string) \preg_replace(...)` has been changed to:

```php
$tmp = \preg_replace(...);
if ($tmp !== null) {
    $str = (string) $tmp;
}
```

This ensures that the original string `$str` is preserved if `preg_replace` returns `null`, preventing unintended data truncation. This fix has been applied consistently to all `preg_replace` calls within the `AntiXSS.php` file that were susceptible to this issue, covering 6 additional locations beyond the initial fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/160)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced anti-XSS protection with improved null value handling in string processing operations for more reliable security filtering behavior and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->