### PR TITLE
Add regression test for issue #201 (template + slot onslotchange XSS)

### DIFF
--- a/tests/JsXssTest.php
+++ b/tests/JsXssTest.php
@@ -153,6 +153,9 @@ final class JsXssTest extends \PHPUnit\Framework\TestCase
 
         static::assertSame('<div><template shadowrootmode="open"><slot ></slot></template><span>x</span></div>', (new AntiXSS())->xss_clean('<div><template shadowrootmode="open"><slot onslotchange=alert(1)></slot></template><span>x</span></div>'));
 
+        // https://github.com/voku/anti-xss/issues/201
+        static::assertSame('<template shadowrootmode=open><slot >', (new AntiXSS())->xss_clean('<template shadowrootmode=open><slot onslotchange=fetch(\'exemple.com\')>'));
+
         static::assertSame('&lt;form &gt;&lt;button&gt;go&lt;/button&gt;&lt;/form&gt;', (new AntiXSS())->xss_clean('<form onformdata=alert(1)><button>go</button></form>'));
 
         static::assertSame('', (new AntiXSS())->xss_clean('<<SCRIPT>alert("XSS");//<</SCRIPT>'));


### PR DESCRIPTION
The exact unquoted-attribute payload from the report is already
neutralized by the onSlotChange handling added in 10376fe, but that
fix was never covered by a test using this literal payload shape
(unquoted attribute value, self-closing slot). Add it explicitly so
any future regression is caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization for embedded template/shadow DOM content by removing blocked event handlers while preserving the surrounding structure.
* **Tests**
  * Added regression coverage for the sanitization behavior to prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/202)
<!-- Reviewable:end -->
