### PR TITLE
Harden GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Archive logs artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logs_composer-${{ matrix.composer }}_php-${{ matrix.php }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -37,10 +40,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
@@ -52,7 +55,7 @@ jobs:
         run: echo "directory=$(composer config cache-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.composer-cache.outputs.directory }}
           key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -109,13 +112,13 @@ jobs:
 
       - name: Upload coverage results to Codecov
         if: ${{ matrix.php == '8.3' && matrix.composer == 'basic' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: build/logs/clover.xml
-      
+
       - name: Archive logs artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: logs_composer-${{ matrix.composer }}_php-${{ matrix.php }}
           path: |


### PR DESCRIPTION
## What changed

- restrict the workflow `GITHUB_TOKEN` to `contents: read`
- pin every referenced GitHub Action to an immutable full commit SHA
- retain version comments next to each SHA for readable dependency updates

Pinned actions:

- `actions/checkout` (`v7.0.1`)
- `shivammathur/setup-php` (`v2.37.2`)
- `actions/cache` (`v6.1.0`)
- `codecov/codecov-action` (`v7.0.0`)
- `actions/upload-artifact` (`v7.0.1`)

## Why

The previous workflow referenced mutable major-version tags and did not declare explicit token permissions. If an upstream tag were moved or compromised, the workflow could execute different code than the revision originally reviewed. Explicit read-only permissions also reduce the impact of a compromised CI step.

## Impact

Runtime library behavior is unchanged. The modification is limited to `.github/workflows/ci.yml`; the existing PHP test matrix, coverage uploads, PHPStan, and Infection commands remain unchanged.

## Validation

- YAML syntax parsed successfully
- diff contains only `.github/workflows/ci.yml`
- action tags were resolved to their exact release commits before pinning
- the hardened workflow completed successfully with the reduced token permissions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/203)
<!-- Reviewable:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow security by enforcing read-only repository access.
  * Pinned automated build and reporting tools to specific immutable versions for more reliable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->