### PR TITLE
Pin agent-loop CI actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,12 +129,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: 8.3
           coverage: none


### PR DESCRIPTION
## What changed

- pin the `agent-loop` job's `actions/checkout` reference to the same reviewed `v7.0.1` commit used by the test job
- pin the `agent-loop` job's `shivammathur/setup-php` reference to the same reviewed `v2.37.2` commit used by the test job

## Why

PR #203 hardened the workflow, but the `agent-loop` job was added later with mutable major-version tags. This restores the workflow-wide invariant that every referenced GitHub Action is pinned to an immutable commit SHA.

## Scope

Only `.github/workflows/ci.yml`; no workflow behavior changes beyond immutable action resolution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/anti-xss/207)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned continuous integration workflow actions to specific revisions for more consistent and reliable build runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->